### PR TITLE
RFC 5424 Logging Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ looking at them, but here's a quickstart guide.
 To load `cl-syslog`, use Quicklisp or ASDF as usual:
 
 ```
-> (ql:quickload :cl-syslog)`
+> (ql:quickload :cl-syslog)
 ;; or, if ASDF can already see it:
 > (asdf:load-system :cl-syslog)
 ```
@@ -89,10 +89,11 @@ by "structured data IDs", and the standard IDs are `timeQuality`,
 parameters.
 
 Personal structured data IDs must have some name, followed by `@`,
-followed by a usually 5 digit integer. For instance, `mycompany@0001`
-is a valid personal structured data ID. One can define a structured
-data ID using `cl-syslog:define-structured-data-id`. The definition of
-the standard `origin` ID is:
+followed by a usually 4 or 5 digit integer. For instance,
+`mycompany@0001` is a valid personal structured data ID. One can
+define a structured data ID using
+`cl-syslog:define-structured-data-id`. The definition of the standard
+`origin` ID is:
 
 ```
 (define-structured-data-id |origin| (:standard t)
@@ -160,8 +161,8 @@ message ID is `"LOG1234"`, then we could write the above message as:
 ### RFC 5424 Caveats
 
 Currently, Unicode isn't properly handled. It is expected all data is
-ASCII. It is also expect your Lisp's `char-code` matches ASCII. The
-necessary BOM will not be inserted for Unicode.
+ASCII. It is also expect that your Lisp's `char-code` matches
+ASCII. The necessary BOM will not be inserted for Unicode.
 
 The RFC 5424 log handling functions generally write to streams, but
 the entry points cons up strings (if and only if the log message is

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ support it by checking if `cl-syslog::rfc5424` is present in your
 `*features*`.)
 
 The first thing you'll need to do is create an instance of the
-`rfc5424-logger` class, filling out as many requisite details as you
-please. The only required slot is `:facility`, but you're encouraged
-to fill out as many slots as you can so that log messages contain more
-information.
+`rfc5424-logger` class, filling out as many details as you
+please. You're encouraged to fill out as many slots as you can so that
+log messages contain more information.
 
 Of particular interest is the `:log-writer` initarg. This controls how
 log messages get processed in the end. The default log writer will use
@@ -62,8 +61,8 @@ in writing to standard output, you can supply
 ```
 (defparameter *logger*
  (make-instance 'cl-syslog:rfc5424-logger
-                :facility ':local0
                 ;; optional
+                :facility ':local0
                 :app-name "MyApp"
                 :hostname "computer.local"
                 :log-writer (cl-syslog:stream-log-writer)))
@@ -134,6 +133,8 @@ the following:
     (|mycompany@0001|
      |who| "John Doe"
      |what| "Needs to buy a new computer."))
+
+;; output:
 <132>1 2018-12-13T22:28:02Z computer.local MyApp 69840 - [origin ip="1.2.3.4" software="My Testing App" swVersion="12.2"][mycompany@0001 who="John Doe" what="Needs to buy a new computer."] Running out of memory! I got 10 bytes left!
 ```
 
@@ -151,6 +152,8 @@ message ID is `"LOG1234"`, then we could write the above message as:
     (|mycompany@0001|
      |who| "John Doe"
      |what| "Needs to buy a new computer."))
+
+;; output:
 <132>1 2018-12-13T22:29:36Z computer.local MyApp 69840 LOG1234 [origin ip="1.2.3.4" software="My Testing App" swVersion="12.2"][mycompany@0001 who="John Doe" what="Needs to buy a new computer."] Running out of memory! I got 10 bytes left!
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,49 +2,193 @@
 
 Common Lisp interface to local and remote Syslog facilities.
 
-FEATURES
-========
- * Local sysloging implemented via foreign-function calls.
- * Remote syslog over UDP sockets.
+## Features
 
-DOCUMENTATION
-=============
-For UDP Syslog See udp-syslog.lisp documentation strings.
-For local syslog see cl-syslog.lisp and variable.lisp.
-Priorities and facilities documented in variable.lisp.
+* Local sysloging implemented via foreign-function calls.
+* Remote syslog over UDP sockets.
+* Optional, complete RFC5424 support.
 
-Examples
-========
-Local Syslog Example:
-    * (require :cl-syslog)
-      
-    * (syslog:log "myprog" :local7 :info "this is the message")
-   "this is the message"
+## Documentation
 
-    * (syslog:log "myprog" :local7 :info "this is the message" 
-        syslog:+log-pid+)
-   "this is the message"
+The source files are relatively well documented, so we recommend
+looking at them, but here's a quickstart guide.
 
-    * (syslog:log "myprog" :local7 :info "this is the message" 
-        (+ syslog:+log-pid+ syslog:+log-cons+))
-    "this is the message"
- 
-Then look in your /var/log/messages or other location if you have
-tweaked your /etc/syslog.conf.
+### Basic Usage
 
-Remote Syslog Example:
-    (require :cl-syslog)
-    ;; Create global logger
-    (syslog.udp:udp-logger "127.0.0.1" 514)
+To load `cl-syslog`, use Quicklisp or ASDF as usual:
 
-    ;; Log a message
-    ;; (Note: the log function is signature compatible with cl-syslog:log)
-    (syslog.udp:log "MyApp" :local7 :info "this is the message")
+```
+> (ql:quickload :cl-syslog)`
+;; or, if ASDF can already see it:
+> (asdf:load-system :cl-syslog)
+```
 
-    ;; Log using a transient logger along with ulog function
-    (syslog-udp:ulog "this is the message" :logger 
-      (syslog-udp:udp-logger "192.168.0.5" 514 :transient t))
+Priorities and facilities are stated by their keyword name. For
+instance, the priority `:warning` on facility `:user`. All of these
+keywords are housed in the variables `*priorities*` and
+`*variables*`. Should you provide invalid facilities or priorities,
+the conditions `cl-syslog:invalid-facility` and
+`cl-syslog:invalid-priority` will be signaled.
 
-    ;; Log with prirority
-    (syslog.udp:ulog "this is an error" :pri :err)
+To log to your local syslog daemon, use `cl-syslog:log` (note that
+this is shadowed, and is obviously not the same as `cl:log`!):
+
+```
+> (cl-syslog:log "MyApp" ':user ':warning "Low on memory.")
+```
+
+Then look in your `/var/log/messages` or other location if you have
+tweaked your `/etc/syslog.conf`. On macOS, you can use the Console
+application.
+
+### RFC 5424 Support
+
+RFC 5424 is supported. (You can check if your CL-SYSLOG installation
+support it by checking if `cl-syslog::rfc5424` is present in your
+`*features*`.)
+
+The first thing you'll need to do is create an instance of the
+`rfc5424-logger` class, filling out as many requisite details as you
+please. The only required slot is `:facility`, but you're encouraged
+to fill out as many slots as you can so that log messages contain more
+information.
+
+Of particular interest is the `:log-writer` initarg. This controls how
+log messages get processed in the end. The default log writer will use
+a function wrapping `cl-syslog:log`. Should you instead be interested
+in writing to standard output, you can supply
+`(cl-syslog:stream-log-writer)` as an argument, like so:
+
+```
+(defparameter *logger*
+ (make-instance 'cl-syslog:rfc5424-logger
+                :facility ':local0
+                ;; optional
+                :app-name "MyApp"
+                :hostname "computer.local"
+                :log-writer (cl-syslog:stream-log-writer)))
+```
+
+There are a few options for log writers, including a UDP log writer
+for remote RFC-compliant logging. You can always support your own
+`lambda` function, too.
+
+Once you have a logger, the simplest way to create a compliant message
+is to use `cl-syslog:format-log`:
+
+```
+> (cl-syslog:format-log *logger* ':warning "Low on memory.")
+<132>1 2018-12-13T22:17:56Z computer.local MyApp 69840 - - Low on memory.
+```
+
+RFC 5424 has support for sending structured data within the log
+message. It's a somewhat complicated arrangement, in that the
+structured data has to be defined and "agreed upon". Specifically,
+there are a set of IETF-approved structured data. They're identified
+by "structured data IDs", and the standard IDs are `timeQuality`,
+`origin`, and `meta`. Each of these have different structured data
+parameters.
+
+Personal structured data IDs must have some name, followed by `@`,
+followed by a usually 5 digit integer. For instance, `mycompany@0001`
+is a valid personal structured data ID. One can define a structured
+data ID using `cl-syslog:define-structured-data-id`. The definition of
+the standard `origin` ID is:
+
+```
+(define-structured-data-id |origin| (:standard t)
+  (|ip| :allow-repetitions t
+        :validator 'ip-address-p)
+  |enterpriseId|
+  (|software| :length (integer 0 40))
+  (|swVersion| :length (integer 0 32)))
+```
+
+(This can be seen in the file [`rfc5424-reserved.lisp`](rfc5424-reserved.lisp).)
+
+Your own structured data ID might be:
+
+```
+(cl-syslog:define-structured-data-id |mycompany@0001| ()
+  |who|
+  |what|)
+```
+
+Note that the field names are escaped to follow the RFC's usual
+idiom. Also node that the field names are here symbols scoped to your
+package. CL-SYSLOG exports all of the symbols of the standard ID's.
+
+How can we use these? We use the log macro `rfc-log`. It's a macro
+because it does extra work at compile time to build code that *only*
+runs if the log message is to be sent.
+
+Suppose we've defined the above structured data ID. Then we might log
+the following:
+
+```
+> (cl-syslog:rfc-log (*logger* :warning "Running out of memory! I got ~D byte~:P left!" 10)
+    (cl-syslog:|origin|
+     cl-syslog:|ip| "1.2.3.4"
+     cl-syslog:|software| "My Testing App"
+     cl-syslog:|swVersion| "12.2")
+    (|mycompany@0001|
+     |who| "John Doe"
+     |what| "Needs to buy a new computer."))
+<132>1 2018-12-13T22:28:02Z computer.local MyApp 69840 - [origin ip="1.2.3.4" software="My Testing App" swVersion="12.2"][mycompany@0001 who="John Doe" what="Needs to buy a new computer."] Running out of memory! I got 10 bytes left!
+```
+
+Optionally, a message ID string can be supplied. This is useful if the
+message is a part of a category of similar messages. Suppose the
+message ID is `"LOG1234"`, then we could write the above message as:
+
+```
+> (cl-syslog:rfc-log (*logger* :warning "Running out of memory! I got ~D byte~:P left!" 10)
+    (:msgid "LOG1234")
+    (cl-syslog:|origin|
+     cl-syslog:|ip| "1.2.3.4"
+     cl-syslog:|software| "My Testing App"
+     cl-syslog:|swVersion| "12.2")
+    (|mycompany@0001|
+     |who| "John Doe"
+     |what| "Needs to buy a new computer."))
+<132>1 2018-12-13T22:29:36Z computer.local MyApp 69840 LOG1234 [origin ip="1.2.3.4" software="My Testing App" swVersion="12.2"][mycompany@0001 who="John Doe" what="Needs to buy a new computer."] Running out of memory! I got 10 bytes left!
+```
+
+### Raw C Functions
+
+The raw C interfaces are CFFI-accessible by their standard UNIX names:
+`openlog`, `closelog`, and `syslog`. None of these are necessary
+unless you are looking for complete control. Beware, if you mess these
+calls up, you will break your Lisp process.
+
+### Remote (UDP) Syslog
+
+*Note*: This interface is subject to change.
+
+UDP messaging can be done with the `udp-log-writer` with the RFC
+logger, but a more direct interface is also supplied. These UDP
+functions are housed in the `syslog-udp` package:
+
+Set up the global UDP logger:
+
+```
+> (syslog.udp:udp-logger "127.0.0.1" 514)
+```
+
+Log a message:
+
+```
+(syslog.udp:log "MyApp" :local7 :info "this is the message")
+```
+
+Log using a transient logger along with ulog function:
+```
+(syslog-udp:ulog "this is the message" :logger 
+  (syslog-udp:udp-logger "192.168.0.5" 514 :transient t))
+```
+
+Log with a priority:
+```
+(syslog.udp:ulog "this is an error" :pri :err)
+```
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ message ID is `"LOG1234"`, then we could write the above message as:
 <132>1 2018-12-13T22:29:36Z computer.local MyApp 69840 LOG1234 [origin ip="1.2.3.4" software="My Testing App" swVersion="12.2"][mycompany@0001 who="John Doe" what="Needs to buy a new computer."] Running out of memory! I got 10 bytes left!
 ```
 
+### RFC 5424 Caveats
+
+Currently, Unicode isn't properly handled. It is expected all data is
+ASCII. It is also expect your Lisp's `char-code` matches ASCII. The
+necessary BOM will not be inserted for Unicode.
+
+The RFC 5424 log handling functions generally write to streams, but
+the entry points cons up strings (if and only if the log message is
+actually sent). There is currently no support for allowing streaming
+log data at the log generation level.
+
+Many log processors do not implement all of RFC 5424, but nonetheless
+cope rather well with the format, and can understand the RFC's
+`key=value` pairs.
+
 ### Raw C Functions
 
 The raw C interfaces are CFFI-accessible by their standard UNIX names:

--- a/cl-syslog.asd
+++ b/cl-syslog.asd
@@ -10,7 +10,7 @@
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
   :description "Local-only syslog logging."
-  :depends-on (#:alexandria #:cffi #:global-vars #:usocket)
+  :depends-on (#:alexandria #:cffi #:global-vars #:usocket #:split-sequence)
   :serial t
   :components ((:file "package")
                (:file "variable")

--- a/cl-syslog.asd
+++ b/cl-syslog.asd
@@ -10,7 +10,7 @@
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
   :description "Local-only syslog logging."
-  :depends-on (#:alexandria #:babel #:cffi #:global-vars)
+  :depends-on (#:alexandria #:cffi #:global-vars)
   :serial t
   :components ((:file "package")
                (:file "variable")

--- a/cl-syslog.asd
+++ b/cl-syslog.asd
@@ -3,17 +3,14 @@
   :version (:read-file-form "VERSION.txt")
   :licence "MIT (See LICENSE)"
   :description "Common Lisp syslog interface."
-  :in-order-to ((asdf:test-op (asdf:test-op #:cl-syslog-tests)))
-  :depends-on (#:cl-syslog.local #:cl-syslog.udp))
+  :in-order-to ((asdf:test-op (asdf:test-op #:cl-syslog/tests)))
+  :depends-on (#:cl-syslog/local #:cl-syslog/udp))
 
-(asdf:defsystem #:cl-syslog.local
+(asdf:defsystem #:cl-syslog/local
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
   :description "Local-only syslog logging."
-  :depends-on (#:alexandria #:babel #:cffi #:global-vars
-                            ; temporary
-                            #:usocket
-                            )
+  :depends-on (#:alexandria #:babel #:cffi #:global-vars)
   :serial t
   :components ((:file "package")
                (:file "variable")
@@ -21,24 +18,24 @@
                (:file "rfc5424")
                (:file "rfc5424-reserved")))
 
-(asdf:defsystem #:cl-syslog.udp
+(asdf:defsystem #:cl-syslog/udp
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
-  :description "Local-only syslog logging."
-  :depends-on (#:cl-syslog.local #:babel #:cffi #:usocket #:local-time)
+  :description "UDP syslog logging."
+  :depends-on (#:cl-syslog/local #:babel #:cffi #:usocket #:local-time)
   :serial t
   :components ((:file "package-udp")
                (:file "udp-syslog")))
 
 
-(asdf:defsystem #:cl-syslog-tests
+(asdf:defsystem #:cl-syslog/tests
   :description "tests for cl-syslog library"
   :version (:read-file-form "VERSION.txt")
   :author "Mike Maul <mike.maul@gmail.com>"
   :licence "MIT"
   :depends-on (#:cl-syslog #:nst #:cl-ppcre)
   :perform (asdf:test-op (o s)
-                         (uiop:symbol-call :cl-syslog-tests '#:run-all-tests))
+             (uiop:symbol-call :cl-syslog-tests '#:run-all-tests))
   :pathname "tests/"
   :serial t
   :components ((:file "package")

--- a/cl-syslog.asd
+++ b/cl-syslog.asd
@@ -10,12 +10,16 @@
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
   :description "Local-only syslog logging."
-  :depends-on (#:alexandria #:babel #:cffi)
+  :depends-on (#:alexandria #:babel #:cffi #:global-vars
+                            ; temporary
+                            #:usocket
+                            )
   :serial t
   :components ((:file "package")
                (:file "variable")
                (:file "cl-syslog")
-               (:file "rfc5424")))
+               (:file "rfc5424")
+               (:file "rfc5424-reserved")))
 
 (asdf:defsystem #:cl-syslog.udp
   :license "MIT (See LICENSE)"

--- a/cl-syslog.asd
+++ b/cl-syslog.asd
@@ -10,7 +10,7 @@
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
   :description "Local-only syslog logging."
-  :depends-on (#:alexandria #:cffi #:global-vars)
+  :depends-on (#:alexandria #:cffi #:global-vars #:usocket)
   :serial t
   :components ((:file "package")
                (:file "variable")

--- a/cl-syslog.asd
+++ b/cl-syslog.asd
@@ -10,11 +10,12 @@
   :license "MIT (See LICENSE)"
   :version (:read-file-form "VERSION.txt")
   :description "Local-only syslog logging."
-  :depends-on (#:cffi)
+  :depends-on (#:alexandria #:babel #:cffi)
   :serial t
   :components ((:file "package")
                (:file "variable")
-               (:file "cl-syslog")))
+               (:file "cl-syslog")
+               (:file "rfc5424")))
 
 (asdf:defsystem #:cl-syslog.udp
   :license "MIT (See LICENSE)"

--- a/cl-syslog.lisp
+++ b/cl-syslog.lisp
@@ -46,14 +46,14 @@
   "Return facility number given the facility's name.  If there is no
 such facility, signal `invalid-facility' error."
   (ash (or (cdr (assoc facility-name *facilities*))
-           (error (make-condition 'invalid-facility :facility facility-name)))
+           (error 'invalid-facility :facility facility-name))
        3))
 
 (defun get-priority (priority-name)
   "Return priority number given the priority's name.  If there is no
 such priority, signal `invalid-priority' error."
   (or (cdr (assoc priority-name *priorities*))
-      (error (make-condition 'invalid-priority :priority priority-name))))
+      (error 'invalid-priority :priority priority-name)))
 
 ;;
 ;; Log function

--- a/cl-syslog.lisp
+++ b/cl-syslog.lisp
@@ -1,9 +1,6 @@
-;;;; $Id: cl-syslog.lisp,v 1.3 2006/11/28 19:46:09 lnostdal Exp $
-;;;; $Source: /project/cl-syslog/cvsroot/cl-syslog/cl-syslog.lisp,v $
-
 ;;;; See the LICENSE file for licensing information.
 
-(in-package :syslog)
+(in-package #:syslog)
 
 ;;
 ;; Condition
@@ -36,7 +33,8 @@
 
 (cffi:defcfun "syslog" :void
   (priority :int)
-  (format :string)) 
+  (format :string)
+  &rest)
 
 ;;
 ;; Utility
@@ -59,11 +57,11 @@ such priority, signal `invalid-priority' error."
 ;; Log function
 ;;
 
-(defun log (name facility priority text &optional (option 0) &rest r)
+(defun log (name facility priority text &optional (option 0))
   "Print message to syslog.
 'option' can be any of the +log...+ constants"
   (cffi:with-foreign-strings ((cname name) (ctext text))
     (openlog cname option (get-facility facility))
-    (syslog (get-priority priority) ctext)
+    (syslog (get-priority priority) "%s" :string ctext)
     (closelog))
   text)

--- a/cl-syslog.local.asd
+++ b/cl-syslog.local.asd
@@ -1,0 +1,3 @@
+(defsystem cl-syslog.local
+  :description "Deprecated! Use cl-syslog/local."
+  :depends-on (#:cl-syslog/local))

--- a/cl-syslog.tests.asd
+++ b/cl-syslog.tests.asd
@@ -1,0 +1,3 @@
+(defsystem cl-syslog.tests
+  :description "Deprecated! Use cl-syslog/tests."
+  :depends-on (#:cl-syslog/tests))

--- a/cl-syslog.udp.asd
+++ b/cl-syslog.udp.asd
@@ -1,0 +1,3 @@
+(defsystem cl-syslog.udp
+  :description "Deprecated! Use cl-syslog/udp."
+  :depends-on (#:cl-syslog/udp))

--- a/package.lisp
+++ b/package.lisp
@@ -1,9 +1,13 @@
 ;;;; See the LICENSE file for licensing information.
 
+(in-package #:cl-user)
+
 (defpackage #:cl-syslog
   (:nicknames #:syslog)
   (:use #:cl)
   (:shadow #:log)
+  ;; *FEATURES* symbols
+  (:export #:rfc5424)
   ;; Basic syslog logging interface.
   (:export #:log
            #:get-facility
@@ -43,7 +47,8 @@
    #:|language|)
   (:documentation "Common Lisp interface to syslog."))
 
-
-
-
-  
+(eval-when (:load-toplevel :execute)
+  ;; :CL-SYSLOG-RFC5424 indicates that the loaded syslog conforms to
+  ;; the RFC 5424 standard. We sould like to indicate this feature is
+  ;; present only until after the logging library is loaded.
+  (pushnew 'cl-syslog::rfc5424 *features*))

--- a/package.lisp
+++ b/package.lisp
@@ -23,6 +23,9 @@
   ;; RFC 5424 logging
   (:export #:define-structured-data-id  ; MACRO
            #:malformed-rfc5424-input    ; CONDITION
+           #:stream-log-writer          ; FUNCTION
+           #:tee-to-stream              ; FUNCTION
+           #:udp-log-writer             ; FUNCTION
            #:rfc5424-logger             ; CLASS
            #:current-time               ; GENERIC, METHOD
            #:log-string                 ; GENERIC, METHOD

--- a/package.lisp
+++ b/package.lisp
@@ -8,29 +8,38 @@
   (:shadow #:log)
   ;; *FEATURES* symbols
   (:export #:rfc5424)
+  ;; Raw C interface
+  (:export
+   #:openlog
+   #:closelog
+   #:syslog)
+
   ;; Basic syslog logging interface.
-  (:export #:log
-           #:get-facility
-           #:get-priority
-           #:+log-pid+
-           #:+log-cons+
-           #:+log-odelay+
-           #:+log-ndelay+
-           #:+log-nowait+
-           #:+log-perror+
-           #:invalid-priority
-           #:invalid-facility)
+  (:export
+   #:log
+   #:get-facility
+   #:get-priority
+   #:+log-pid+
+   #:+log-cons+
+   #:+log-odelay+
+   #:+log-ndelay+
+   #:+log-nowait+
+   #:+log-perror+
+   #:invalid-priority
+   #:invalid-facility)
+
   ;; RFC 5424 logging
-  (:export #:define-structured-data-id  ; MACRO
-           #:malformed-rfc5424-input    ; CONDITION
-           #:stream-log-writer          ; FUNCTION
-           #:tee-to-stream              ; FUNCTION
-           #:udp-log-writer             ; FUNCTION
-           #:rfc5424-logger             ; CLASS
-           #:current-time               ; GENERIC, METHOD
-           #:log-string                 ; GENERIC, METHOD
-           #:rfc-log                    ; MACRO
-           )
+  (:export
+   #:define-structured-data-id  ; MACRO
+   #:malformed-rfc5424-input    ; CONDITION
+   #:stream-log-writer          ; FUNCTION
+   #:tee-to-stream              ; FUNCTION
+   #:udp-log-writer             ; FUNCTION
+   #:rfc5424-logger             ; CLASS
+   #:current-time               ; GENERIC, METHOD
+   #:format-log                 ; GENERIC, METHOD
+   #:rfc-log                    ; MACRO
+   )
   ;; RFC 5424 IETF-reserved structured data names
   (:export
    #:|timeQuality|

--- a/package.lisp
+++ b/package.lisp
@@ -4,6 +4,7 @@
   (:nicknames #:syslog)
   (:use #:cl)
   (:shadow #:log)
+  ;; Basic syslog logging interface.
   (:export #:log
            #:get-facility
            #:get-priority
@@ -15,6 +16,31 @@
            #:+log-perror+
            #:invalid-priority
            #:invalid-facility)
+  ;; RFC 5424 logging
+  (:export #:define-structured-data-id  ; MACRO
+           #:malformed-rfc5424-input    ; CONDITION
+           #:rfc5424-logger             ; CLASS
+           #:current-time               ; GENERIC, METHOD
+           #:log-string                 ; GENERIC, METHOD
+           #:rfc-log                    ; MACRO
+           )
+  ;; RFC 5424 IETF-reserved structured data names
+  (:export
+   #:|timeQuality|
+   #:|tzKnown|
+   #:|isSynced|
+   #:|syncAccuracy|
+
+   #:|origin|
+   #:|ip|
+   #:|enterpriseId|
+   #:|software|
+   #:|swVersion|
+
+   #:|meta|
+   #:|sequenceId|
+   #:|sysUpTime|
+   #:|language|)
   (:documentation "Common Lisp interface to syslog."))
 
 

--- a/package.lisp
+++ b/package.lisp
@@ -30,15 +30,18 @@
 
   ;; RFC 5424 logging
   (:export
-   #:define-structured-data-id  ; MACRO
-   #:malformed-rfc5424-input    ; CONDITION
-   #:stream-log-writer          ; FUNCTION
-   #:tee-to-stream              ; FUNCTION
-   #:udp-log-writer             ; FUNCTION
-   #:rfc5424-logger             ; CLASS
-   #:current-time               ; GENERIC, METHOD
-   #:format-log                 ; GENERIC, METHOD
-   #:rfc-log                    ; MACRO
+   #:define-structured-data-id          ; MACRO
+   #:malformed-rfc5424-input            ; CONDITION
+   #:null-log-writer                    ; FUNCTION
+   #:syslog-log-writer                  ; FUNCTION
+   #:stream-log-writer                  ; FUNCTION
+   #:udp-log-writer                     ; FUNCTION
+   #:tee-to-stream                      ; FUNCTION
+   #:join-log-writers                   ; FUNCTION
+   #:rfc5424-logger                     ; CLASS
+   #:current-time                       ; GENERIC, METHOD
+   #:format-log                         ; GENERIC, METHOD
+   #:rfc-log                            ; MACRO
    )
   ;; RFC 5424 IETF-reserved structured data names
   (:export

--- a/rfc5424-reserved.lisp
+++ b/rfc5424-reserved.lisp
@@ -1,0 +1,29 @@
+(in-package #:cl-syslog)
+
+;;;; Section 7.
+;;;;
+;;;; These are IETF-reserved structure ID's.
+
+(define-structured-data-id |timeQuality| (:standard t)
+  (|tzKnown| :length (integer 1 1)
+             :validator (lambda (x) (member x '("0" "1") :test #'string=)))
+  (|isSynced| :length (integer 1 1)
+              :validator (lambda (x) (member x '("0" "1") :test #'string=)))
+  (|syncAccuracy| :validator (lambda (x) (every #'digit-char-p x))))
+
+(defun ip-address-p (x)
+  (declare (ignore x))
+  ;; TODO: actually parse an IP address
+  t)
+
+(Define-structured-data-id |origin| (:standard t)
+  (|ip| :allow-repetitions t
+        :validator 'ip-address-p)
+  |enterpriseId|
+  (|software| :length (integer 0 40))
+  (|swVersion| :length (integer 0 32)))
+
+(define-structured-data-id |meta| (:standard t)
+  |sequenceId|
+  |sysUpTime|
+  |language|)

--- a/rfc5424-reserved.lisp
+++ b/rfc5424-reserved.lisp
@@ -11,10 +11,33 @@
               :validator (lambda (x) (member x '("0" "1") :test #'string=)))
   (|syncAccuracy| :validator (lambda (x) (every #'digit-char-p x))))
 
+(defun ip4-address-p (x)
+  (flet ((valid-group-p (x)
+           (and (<= 1 (length x) 3)
+                (every #'digit-char-p x)
+                (or (string= "0" x)
+                    (not (char= #\0 (char x 0))))
+                (<= 0 (parse-integer x) 255))))
+    (and (stringp x)
+         (= 3 (count #\. x))
+         (every #'valid-group-p (split-sequence:split-sequence #\. x)))))
+
+(defun ip6-address-p (x)
+  (labels ((hex-digit-char-p (c)
+             (or (digit-char-p c)
+                 (find c "aAbBcCdDeEfF")))
+           (valid-group-p (x)
+             (or (zerop (length x))
+                 (and (= 4 (length x))
+                      (every #'hex-digit-char-p x)
+                      (<= 0 (parse-integer x :radix 16) #xFFFF)))))
+    (and (stringp x)
+         (= 7 (count #\: x))
+         (every #'valid-group-p (split-sequence:split-sequence #\: x)))))
+
 (defun ip-address-p (x)
-  (declare (ignore x))
-  ;; TODO: actually parse an IP address
-  t)
+  (or (ip4-address-p x)
+      (ip6-address-p x)))
 
 (define-structured-data-id |origin| (:standard t)
   (|ip| :allow-repetitions t

--- a/rfc5424-reserved.lisp
+++ b/rfc5424-reserved.lisp
@@ -16,7 +16,7 @@
   ;; TODO: actually parse an IP address
   t)
 
-(Define-structured-data-id |origin| (:standard t)
+(define-structured-data-id |origin| (:standard t)
   (|ip| :allow-repetitions t
         :validator 'ip-address-p)
   |enterpriseId|

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -708,7 +708,7 @@ The logging will only happen of LOGGER does not exceed a specified maximum prior
                                       ;; Do we allow repeats?
                                       (when (and recognized?
                                                  already-seen?
-                                                 (structured-data-field-description-repetitions-allowed-p field-descriptor))
+                                                 (not (structured-data-field-description-repetitions-allowed-p field-descriptor)))
                                         (error "Found a repeated field ~S for the structured data ~S, and that's not allowed here."
                                                key
                                                id))

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -1,0 +1,472 @@
+(in-package #:syslog)
+
+;;; In this file, the section names refer to sections of the RFC 5424
+;;; of March 2009.
+;;;
+;;; For all WRITE-* functions, and for most format-checking predicate
+;;; functions, refer to Section 6 "Syslog Message Format", which has
+;;; the ABNF grammar for the messages.
+
+(declaim (inline ascii-char-p))
+(defun ascii-char-p (c)
+  (<= 0 (char-code c) 127))
+
+(declaim (inline ascii-control-char-p))
+(defun ascii-control-char-p (c)
+  (let ((code (char-code c)))
+    (or (= code 32)
+        (= code 127))))
+
+(declaim (inline ascii-graphic-char-p))
+(defun ascii-graphic-char-p (c)
+  (not (ascii-control-char-p c)))
+
+(declaim (inline ascii-graphic-string-p))
+(defun ascii-graphic-string-p (x)
+  (and (stringp x)
+       (every #'ascii-graphic-char-p x)))
+
+(declaim (ascii-whitespace-char-p))
+(defun ascii-whitespace-char-p (c)
+  (and (member c '(#\Tab #\Newline #\Linefeed #\Page #\Return #\Space))
+       t))
+
+;;; Section 6.2. HEADER
+
+;;; Section 6.2.1. PRI
+
+(deftype rfc5424-pri ()
+  ;; A <PRI> value is constructed by the formula
+  ;;
+  ;;     PRIORITY(0-7) + 8 * FACILITY(0-23)
+  ;;
+  ;; which means there are 8 * 24 possible choices.
+  `(integer 0 (,(* 8 24))))
+
+(defun valid-pri-p (thing)
+  (typep thing 'rfc5424-pri))
+
+(defun write-pri (stream pri)
+  (format stream "<~D>" pri))
+
+
+;;; Section 6.2.2. VERSION
+;;;
+;;; The version is just "1".
+(defun write-version (stream)
+  (write-char #\1 stream))
+
+
+;;; Section 6.2.3. TIMESTAMP
+(defun write-two-digit-number (stream number)
+  (format stream "~2,'0D" number))
+
+(defun valid-year-p (x)
+  ;; A year must be a 4-digit integer.
+  (typep x '(integer 1000 9999)))
+
+(defun valid-month-p (x)
+  (typep x '(integer 1 12)))
+
+(defun valid-day-p (x)
+  (typep x '(integer 1 31)))
+
+(defun write-date (stream year month day)
+  (format stream "~D" year)
+  (write-char #\- stream)
+  (write-two-digit-number stream month)
+  (write-char #\- stream)
+  (write-two-digit-number stream day))
+
+(defun valid-hour-p (x)
+  (typep x '(integer 0 23)))
+
+(defun valid-minute-p (x)
+  (typep x '(integer 0 59)))
+
+(defun valid-second-p (x)
+  (typep x '(integer 0 59)))
+
+(defun valid-fraction-of-a-second-p (x)
+  (typep x '(or null (real 0 (1)))))
+
+(defun write-time (stream hour minute second fraction-of-a-second)
+  (write-two-digit-number stream hour)
+  (write-char #\: stream)
+  (write-two-digit-number stream minute)
+  (write-char #\: stream)
+  (write-two-digit-number stream second)
+  (when fraction-of-a-second
+    (write-char #\. stream)
+    ;; six digits are allowed!
+    (format stream "~D" (floor (* fraction-of-a-second #.(expt 10 6)))))
+  nil)
+
+;;; RFC 5424 cross-references RFC 3339 for the meaning of timestamps.
+(defun write-utc-timestamp (stream year month day hour minute second fraction-of-a-second)
+  (write-date stream year month day)
+  (write-char #\T stream)
+  (write-time (stream hour minute second fraction-of-a-second))
+  ;; We *ALWAYS* require UTC time. RFC 5424 allows any time offset,
+  ;; but we'd prefer to be conservative here.
+  (write-char #\Z stream)
+  nil)
+
+
+;;; Section 6.2.4. HOSTNAME
+;;;
+;;; RFC 5424 cross-references RFC 1034 for the format of a domain
+;;; name, but it's only a SHOULD-requirement. It does mandate,
+;;; however, that the string is no more than 255 characters in length.
+(defun valid-hostname-p (thing)
+  (or (null thing)
+      (and (ascii-graphic-string-p thing)
+           (<= 1 (length thing) 255))))
+
+(defun write-hostname (stream hostname)
+  (when hostname
+    (write-string hostname stream))
+  nil)
+
+
+;;; Section 6.2.5. APP-NAME
+
+(defun valid-app-name-p (thing)
+  (or (null thing)
+      (and (ascii-graphic-string-p thing)
+           (<= 1 (length thing) 48))))
+
+(defun write-app-name (stream app-name)
+  (when app-name
+    (write-string app-name stream))
+  nil)
+
+
+;;; Section 6.2.6. PROCID
+
+(defun valid-procid-p (thing)
+  (or (null thing)
+      (and (ascii-graphic-string-p thing)
+           (<= 1 (length thing) 128))))
+
+(defun write-procid (stream procid)
+  (when procid
+    (write-string procid stream))
+  nil)
+
+
+
+;;; Section 6.2.7. MSGID
+
+(defun valid-msgid-p (thing)
+  (or (null thing)
+      (and (ascii-graphic-string-p thing)
+           (<= 1 (length thing) 32))))
+
+(defun write-msgid (stream msgid)
+  (when msgid
+    (write-string msgid stream))
+  nil)
+
+
+;;; Section 6.3. STRUCTURED-DATA
+;;;
+;;; This is quite a complicated section, because it allows arbitrary,
+;;; categorized key-values pairs to be present in the message. Some of
+;;; the pairs are IETF-standardized, some aren't, and there's
+;;; syntactic distinction.
+
+(defstruct structured-data-field-description
+  "A description of a field of structured data."
+  ;; The printable name of the field.
+  (name nil :type alexandria:string-designator :read-only t)
+  ;; Are repetitions of this field allowed?
+  (repetitions-allowed-p nil :type boolean :read-only t)
+  ;; What is the Lisp type that describes the allowed length of the
+  ;; field? By default, this is any non-negative integer.
+  (length-type 'unsigned-byte :read-only t)
+  ;; A function to validate the field. The function should take a
+  ;; value as input, and return T if the value is valid, and NIL
+  ;; otherwise. By default, T is always returned. (Note that this
+  ;; function does not have to check if the input is a string. This
+  ;; will be done at a higher level.)
+  (validator (constantly t) :type function :read-only t))
+
+;;; Enterprise numbers are defined in Section 7.2.2.
+(defun valid-enterprise-number-p (string)
+  "Is the string STRING a valid enterprise number?"
+  (check-type string string)
+  (prog ((length (length string))
+         (i 0))
+     ;; The string must have contents.
+     (when (zerop length)
+       (return nil))
+
+     ;; Fall-through to expecting a digit.
+
+   :EXPECT-DIGIT
+     (unless (digit-char-p (char string i))
+       (return nil))
+     (when (= i (1- length))
+       (return t))
+     (incf i)
+     (go :EXPECT-DIGIT-OR-DOT)
+
+   :EXPECT-DOT
+     (when (or (not (char= #\. (char string i)))
+               (= i (1- length)))
+       (return nil))
+     (incf i)
+     (go :EXPECT-DIGIT)
+
+   :EXPECT-DIGIT-OR-DOT
+     (cond
+       ((char= #\. (char string i))
+        (go :EXPECT-DOT))
+       ((digit-char-p (char string i))
+        (go :EXPECT-DIGIT))
+       (t
+        (return nil)))))
+
+;;; This is the SD-NAME
+(defun valid-sd-name-p (string)
+  (flet ((valid-char-p (char)
+           (and (ascii-char-p char)
+                (not (ascii-control-char-p char))
+                (not (ascii-whitespace-char-p char))
+                (not (member char '(#\@ #\= #\] #\"))))))
+    (declare (inline valid-char-p))
+    (and (<= 1 (length string) 32)
+         (every #'valid-char-p string))))
+
+(defun valid-sd-id-p (x)
+  "Is X a valid structured data ID? Roughly, these are either:
+
+    1. A bare ASCII name, in which case it's an IETF-reserved name.
+
+    2. An ASCII name, followed by '@', followed by a number (which may have dots)."
+  (flet ((split (string-designator)
+           (let* ((string (string string-designator))
+                  (position (position #\@ string)))
+             (if (null position)
+                 (values string nil)
+                 (values (subseq string 0 position)
+                         (subseq string (1+ position)))))))
+    (declare (inline split))
+    (and (typep x 'alexandria:string-designator)
+         (multiple-value-bind (before after) (split x)
+           (and (valid-sd-name-p before)
+                (or (null after)
+                    (valid-enterprise-number-p after)))))))
+
+(defstruct structured-data-description
+  "A description of structured data."
+  ;; Section 6.3.2. SD-ID
+  (id nil :type alexandria:string-designator :read-only t)
+  (allow-other-params t :type boolean :read-only t))
+
+
+;;; Section 6.3.3. SD-PARAM
+
+(defun write-param-name (stream string)
+  "Write out the PARAM-NAME STRING to the stream STREAM."
+  (check-type string string)
+  (write-string string stream)
+  nil)
+
+(defun write-param-value (stream string)
+  "Write out the PARAM-VALUE STRING to the stream STREAM."
+  (check-type string string)
+  (loop :for c :of-type character :across string
+        :do (case c
+              ((#\" #\\ #\])            ; Required escape characters.
+               (write-char #\\ stream)
+               (write-char c stream))
+              (otherwise
+               (write-char c stream))))
+  nil)
+
+;;; Section 6.3.1. SD-ELEMENT
+;;;
+;;; We don't use any fancy data structures for the actual SD-ELEMENTs
+;;; since they'll be frequently allocated and thrown away. Lisp is
+;;; good at lists, so let it do its thing.
+;;;
+;;; These functions should be used *after* the contents have been
+;;; validated by the requisite *-DESCRIPTION data structures.
+
+(declaim (inline make-param param-name param-value))
+(defun make-param (name value) (cons name value))
+(defun param-name (param) (car param))
+(defun param-value (param) (cdr param))
+(defun valid-param-p (p)
+  (and (consp p)
+       (valid-sd-name-p (param-name p))
+       ;; FIXME: stringp might need to be more specific. The RFC says
+       ;; it should be a UTF8 string.
+       (stringp (param-value p))))
+
+(declaim (inline make-sd-element sd-element-id sd-element-params))
+(defun make-sd-element (id &rest params) (list* id params))
+(defun sd-element-id (elt) (first elt))
+(defun sd-element-params (elt) (rest elt))
+(defun valid-sd-element-p (e)
+  (and (alexandria:proper-list-p e)
+       (valid-sd-id-p (sd-element-id e))
+       (every #'valid-sd-element-param-p (sd-element-params e))))
+
+(defun write-sd-element (stream elt)
+  (write-char #\[ stream)
+  (write-string (sd-element-id elt) stream)
+  (dolist (param (sd-element-params elt))
+    (write-char #\Space stream)
+    (write-param-name stream (param-name param))
+    (write-char #\= stream)
+    (write-param-value (param-value param)))
+  (write-char #\] stream)
+  nil)
+
+(defun write-sd-elements (stream elts)
+  (dolist (elt elts)
+    (write-sd-element stream elt)))
+
+
+;;; Section 7. Structure Data IDs
+
+(defmacro define-structured-data-id (name args &body body)
+  (declare (ignore name args body))
+  nil)
+
+(define-structured-data-id |timeQuality| ()
+  |tzKnown|
+  |isSynced|
+  |syncAccuracy|)
+
+(define-structured-data-id |origin| ()
+  |ip|
+  |enterpriseId|
+  |software|
+  |swVersion|)
+
+(define-structured-data-id |meta| ()
+  |sequenceId|
+  |sysUpTime|
+  |language|)
+
+
+;;; Section 6.4. MSG
+;;;
+;;; This is the user-supplied message. The RFC asks for the message to
+;;; be Unicode, formatted as UTF-8, but does not require it.
+
+(defun write-msg (stream string)
+  ;; TODO: Deal with the BOM for UTF8 payload.
+  (write-string string stream))
+
+
+;;; Back to Section 6, to bring it all together.
+
+(defun write-rfc5424-syslog-message-unsafe (stream
+                                            pri
+                                            year
+                                            month
+                                            day
+                                            hour
+                                            minute
+                                            second
+                                            fractions-of-a-second
+                                            hostname
+                                            app-name
+                                            procid
+                                            msgid
+                                            sd-elements
+                                            msg)
+  ;; All of this comprises a SYSLOG-MSG.
+
+  ;; HEADER
+  (write-pri stream pri)
+  (write-version stream)                ; Not configurable.
+  (write-char #\Space stream)
+  (write-utc-timestamp stream year month day hour minute second fractions-of-a-second)
+  (write-char #\Space stream)
+  (write-hostname stream hostname)
+  (write-char #\Space stream)
+  (write-app-name stream app-name)
+  (write-char #\Space stream)
+  (write-procid stream procid)
+  (write-char #\Space stream)
+  (write-msgid stream msgid)
+  
+  ;; Done with HEADER. Back up to SYSLOG-MSG.
+  (write-char #\Space stream)
+  
+  ;; STRUCTURED-DATA
+  (write-sd-elements stream sd-elements)
+
+  ;; Done with STRUCTURED-DATA. Back up to SYSLOG-MSG.
+  ;;
+  ;; Only write a space if we have a MSG.
+  (when msg
+    (write-char #\Space stream)
+    (write-msg stream msg))
+  
+  ;; Done. Don't return anything useful.
+  nil)
+
+(define-condition malformed-rfc5424-input (error)
+  ()
+  (:report (lambda (condition stream)
+             (format stream "Malformed input for RFC 5424 syslog message."))))
+
+(defmacro assert-rfc5424 (thing)
+  `(unless ,thing
+     (error 'malformed-rfc5424-input)))
+
+(defun write-rfc5424-syslog-message (stream
+                                     pri
+                                     year
+                                     month
+                                     day
+                                     hour
+                                     minute
+                                     second
+                                     fraction-of-a-second
+                                     hostname
+                                     app-name
+                                     procid
+                                     msgid
+                                     sd-elements
+                                     msg)
+  "Write the RFC 5424-compliant syslog message to the stream STREAM."
+  (check-type stream stream)
+  (assert-rfc5424 (valid-pri-p pri))
+  (assert-rfc5424 (valid-year-p year))
+  (assert-rfc5424 (valid-month-p month))
+  (assert-rfc5424 (valid-day-p day))
+  (assert-rfc5424 (valid-hour-p) hour)
+  (assert-rfc5424 (valid-minute-p minute))
+  (assert-rfc5424 (valid-second-p second))
+  (assert-rfc5424 (valid-fraction-of-a-second-p fraction-of-a-second))
+  (assert-rfc5424 (valid-hostname-p hostname))
+  (assert-rfc5424 (valid-app-name-p app-name))
+  (assert-rfc5424 (valid-procid-p procid))
+  (assert-rfc5424 (valid-msgid-p msgid))
+  (assert-rfc5424 (every #'valid-sd-element-p sd-elements))
+  ;; TODO: fix this. Should be either a collection of octets or a UTF8
+  ;; string.
+  (assert-rfc5424 (stringp msg))
+  (write-rfc5424-syslog-message-unsafe stream
+                                       pri
+                                       year
+                                       month
+                                       day
+                                       hour
+                                       minute
+                                       second
+                                       fraction-of-a-second
+                                       hostname
+                                       app-name
+                                       procid
+                                       msgid
+                                       sd-elements
+                                       msg))

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -26,7 +26,7 @@
   (and (stringp x)
        (every #'ascii-graphic-char-p x)))
 
-(declaim (ascii-whitespace-char-p))
+(declaim (inline ascii-whitespace-char-p))
 (defun ascii-whitespace-char-p (c)
   (and (member c '(#\Tab #\Newline #\Linefeed #\Page #\Return #\Space))
        t))
@@ -99,14 +99,16 @@
   (when fraction-of-a-second
     (write-char #\. stream)
     ;; six digits are allowed!
-    (format stream "~D" (floor (* fraction-of-a-second #.(expt 10 6)))))
+    (if (zerop fraction-of-a-second)
+        (write-string "00" stream)
+        (format stream "~D" (floor (* fraction-of-a-second #.(expt 10 6))))))
   nil)
 
 ;;; RFC 5424 cross-references RFC 3339 for the meaning of timestamps.
 (defun write-utc-timestamp (stream year month day hour minute second fraction-of-a-second)
   (write-date stream year month day)
   (write-char #\T stream)
-  (write-time (stream hour minute second fraction-of-a-second))
+  (write-time stream hour minute second fraction-of-a-second)
   ;; We *ALWAYS* require UTC time. RFC 5424 allows any time offset,
   ;; but we'd prefer to be conservative here.
   (write-char #\Z stream)
@@ -155,7 +157,6 @@
   nil)
 
 
-
 ;;; Section 6.2.7. MSGID
 
 (defun valid-msgid-p (thing)
@@ -184,13 +185,17 @@
   (repetitions-allowed-p nil :type boolean :read-only t)
   ;; What is the Lisp type that describes the allowed length of the
   ;; field? By default, this is any non-negative integer.
+  ;;
+  ;; Currently unused.
   (length-type 'unsigned-byte :read-only t)
   ;; A function to validate the field. The function should take a
   ;; value as input, and return T if the value is valid, and NIL
   ;; otherwise. By default, T is always returned. (Note that this
   ;; function does not have to check if the input is a string. This
   ;; will be done at a higher level.)
-  (validator (constantly t) :type function :read-only t))
+  ;;
+  ;; Currently un-used.
+  (validator (constantly t) :type (or symbol function) :read-only t))
 
 ;;; Enterprise numbers are defined in Section 7.2.2.
 (defun valid-enterprise-number-p (string)
@@ -244,7 +249,14 @@
 
     1. A bare ASCII name, in which case it's an IETF-reserved name.
 
-    2. An ASCII name, followed by '@', followed by a number (which may have dots)."
+    2. An ASCII name, followed by '@', followed by a number (which may have dots).
+
+Return two values:
+
+    1. A Boolean indicating whether it's a valid ID.
+
+    2. A Boolean indicating whether its name conforms to an IETF-reserved name.
+"
   (flet ((split (string-designator)
            (let* ((string (string string-designator))
                   (position (position #\@ string)))
@@ -253,17 +265,30 @@
                  (values (subseq string 0 position)
                          (subseq string (1+ position)))))))
     (declare (inline split))
-    (and (typep x 'alexandria:string-designator)
-         (multiple-value-bind (before after) (split x)
-           (and (valid-sd-name-p before)
-                (or (null after)
-                    (valid-enterprise-number-p after)))))))
+    ;; Is the thing even a string designator?
+    (if (not (typep x 'alexandria:string-designator))
+        (values nil nil)
+        ;; It is. Split at the @-sign.
+        (multiple-value-bind (before after) (split x)
+          (cond
+            ;; Is the thing before any @-sign invalid?
+            ((not (valid-sd-name-p before))
+             (values nil nil))
+            ;; Is whatever's after an @-sign missing?
+            ((null after)
+             (values t t))
+            ;; Is the thing after the @-sign valid?
+            ((valid-enterprise-number-p after)
+             (values t nil))
+            ;; Nothing is right.
+            (t (values nil nil)))))))
 
 (defstruct structured-data-description
   "A description of structured data."
   ;; Section 6.3.2. SD-ID
   (id nil :type alexandria:string-designator :read-only t)
-  (allow-other-params t :type boolean :read-only t))
+  (allow-other-params t :type boolean :read-only t)
+  (fields nil :type alexandria:proper-list :read-only t))
 
 
 ;;; Section 6.3.3. SD-PARAM
@@ -313,7 +338,7 @@
 (defun valid-sd-element-p (e)
   (and (alexandria:proper-list-p e)
        (valid-sd-id-p (sd-element-id e))
-       (every #'valid-sd-element-param-p (sd-element-params e))))
+       (every #'valid-param-p (sd-element-params e))))
 
 (defun write-sd-element (stream elt)
   (write-char #\[ stream)
@@ -322,7 +347,7 @@
     (write-char #\Space stream)
     (write-param-name stream (param-name param))
     (write-char #\= stream)
-    (write-param-value (param-value param)))
+    (write-param-value stream (param-value param)))
   (write-char #\] stream)
   nil)
 
@@ -333,25 +358,83 @@
 
 ;;; Section 7. Structure Data IDs
 
-(defmacro define-structured-data-id (name args &body body)
-  (declare (ignore name args body))
-  nil)
+(global-vars:define-global-var **structured-data-specs** (make-hash-table :test 'equal)
+  "A table mapping structured data ID's (strings) to a STRUCTURED-DATA-DESCRIPTION.")
 
-(define-structured-data-id |timeQuality| ()
-  |tzKnown|
-  |isSynced|
-  |syncAccuracy|)
+(defun find-sd-id (name)
+  (check-type name alexandria:string-designator)
+  (alexandria:if-let ((val (gethash (string name) **structured-data-specs**)))
+    val
+    (error "Couldn't find the structured data ID ~S. Perhaps you haven't ~
+            defined it with DEFINE-STRUCTURED-DATA-ID?"
+           (string name))))
 
-(define-structured-data-id |origin| ()
-  |ip|
-  |enterpriseId|
-  |software|
-  |swVersion|)
+(defun (setf find-sd-id) (new-value name)
+  (check-type name alexandria:string-designator)
+  (check-type new-value structured-data-description)
+  (setf (gethash (string name) **structured-data-specs**) new-value))
 
-(define-structured-data-id |meta| ()
-  |sequenceId|
-  |sysUpTime|
-  |language|)
+(defmacro define-structured-data-id (id-name (&key allow-other-params standard) &body body)
+  "Define a new structured data ID named ID-NAME.
+
+ALLOW-OTHER-PARAMS is an option to allow other named parameters to be present.
+
+STANDARD is an option to dictate that the defined message is an IETF-reserved name.
+
+BODY specifies the fields and has the following syntax:
+
+    <body> ::= <field>*
+
+    <field> ::= <symbol>
+              | (<symbol> [:allow-repetitions <boolean>]
+                          [:length <length-type>]
+                          [:validator <form>])
+
+    <length-type> ::= an unevaluated form that is a subtype of UNSIGNED-BYTE
+
+    <form> ::= an evaluated form producing a funcallable unary function mapping to booleans
+
+The :ALLOW-REPETITIONS keyword allows a field to be repeated (default: nil).
+
+The :LENGTH keyword specifies what the length of the string data must satisfy. By default it's unbounded by UNSIGNED-BYTE.
+
+The :VALIDATOR keyword allows a validating function to be provided. By default it is (CONSTANTLY T).
+"
+  (check-type id-name alexandria:string-designator)
+  (labels ((parse-field (field-name &key (allow-repetitions nil)
+                                         (length 'unsigned-byte)
+                                         (validator '(constantly t)))
+             (check-type field-name alexandria:string-designator)
+             (check-type allow-repetitions boolean)
+             (assert (subtypep length 'unsigned-byte))
+             `(make-structured-data-field-description
+               :name ',(string field-name)
+               :repetitions-allowed-p ',allow-repetitions
+               :length-type ',length
+               :validator ,validator)))
+    (let ((name (string id-name)))
+      (multiple-value-bind (valid? standard?) (valid-sd-id-p name)
+        ;; Check that it's valid.
+        (unless valid?
+          (error "Invalid structured data ID: ~S" name))
+        ;; Ensure that we match our stated standard naming compliance.
+        (unless (eql standard standard?)
+          (error "Declared that ~A ~:[is not~;is~] an IETF-reserved ~
+                  (\"standard\") ID, but it was determined that ~
+                  it ~:[is not~;is~]."
+                 name
+                 standard
+                 standard?))
+
+        `(eval-when (:compile-toplevel :load-toplevel :execute)
+           (setf (find-sd-id ',id-name)
+                 (make-structured-data-description
+                  :id ',name
+                  :allow-other-params ',(and allow-other-params t)
+                  :fields (list ,@(mapcar (lambda (field)
+                                            (apply #'parse-field (alexandria:ensure-list field)))
+                                          body))))
+           ',id-name)))))
 
 
 ;;; Section 6.4. MSG
@@ -396,10 +479,10 @@
   (write-procid stream procid)
   (write-char #\Space stream)
   (write-msgid stream msgid)
-  
+
   ;; Done with HEADER. Back up to SYSLOG-MSG.
   (write-char #\Space stream)
-  
+
   ;; STRUCTURED-DATA
   (write-sd-elements stream sd-elements)
 
@@ -409,13 +492,14 @@
   (when msg
     (write-char #\Space stream)
     (write-msg stream msg))
-  
+
   ;; Done. Don't return anything useful.
   nil)
 
 (define-condition malformed-rfc5424-input (error)
   ()
   (:report (lambda (condition stream)
+             (declare (ignore condition))
              (format stream "Malformed input for RFC 5424 syslog message."))))
 
 (defmacro assert-rfc5424 (thing)
@@ -443,7 +527,7 @@
   (assert-rfc5424 (valid-year-p year))
   (assert-rfc5424 (valid-month-p month))
   (assert-rfc5424 (valid-day-p day))
-  (assert-rfc5424 (valid-hour-p) hour)
+  (assert-rfc5424 (valid-hour-p hour))
   (assert-rfc5424 (valid-minute-p minute))
   (assert-rfc5424 (valid-second-p second))
   (assert-rfc5424 (valid-fraction-of-a-second-p fraction-of-a-second))
@@ -469,4 +553,162 @@
                                        procid
                                        msgid
                                        sd-elements
-                                       msg))
+                                      msg))
+
+
+;;; Public Interface
+;;;
+;;; This isn't specified by RFC, but makes this file convenient to
+;;; use.
+
+(defclass rfc5424-logger ()
+  ((facility :initarg :facility
+             :reader logger-facility)
+   (maximum-priority :initarg :maximum-priority
+                     :reader logger-maximum-priority
+                     :documentation "The maximum priority above which log messages are not emitted to the external logging facility. The default maximum priority is :INFO. (Recall that priorities of *increasing* severity have *decreasing* priority values.)")
+   (hostname :initarg :hostname
+             :reader logger-hostname)
+   (app-name :initarg :app-name
+             :reader logger-app-name)
+   (process-id :initarg :process-id
+               :reader logger-process-id))
+  (:default-initargs :maximum-priority ':info
+                     :hostname (machine-instance)
+                     :app-name nil
+                     :process-id #+(and sbcl unix) (prin1-to-string (sb-posix:getpid))
+                                 #-(and sbcl unix) nil)
+  (:documentation "Default class representing RFC 5424-compliant logging."))
+
+(defgeneric current-time (logger)
+  (:documentation "Return values YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, FRACTION-OF-A-SECOND.")
+  (:method ((logger rfc5424-logger))
+    (multiple-value-bind (second minute hour day month year weekday daylight-p zone)
+        (decode-universal-time (get-universal-time) 0) ; 0 for GMT
+      (declare (ignore daylight-p zone weekday))
+      (values year month day hour minute second 0))))
+
+(defgeneric log-string (logger priority control &rest args)
+  (:documentation "Log the simple message STRING according to the priority PRIORITY.
+
+This should be used in the simplest of logging situations. For more complicated log messages that contain structured data, see the RFC-LOG macro.")
+  (:method ((logger rfc5424-logger) priority control &rest args)
+    (unless (< (get-priority (logger-maximum-priority logger)) (get-priority priority))
+      (multiple-value-bind (year month day hour minute second fraction)
+          (current-time logger)
+        (with-output-to-string (stream)
+          (write-rfc5424-syslog-message stream
+                                        (logior (get-priority priority)
+                                                ;; facility is already shifted by 3 bits
+                                                (get-facility (logger-facility logger)))
+                                        year
+                                        month
+                                        day
+                                        hour
+                                        minute
+                                        second
+                                        fraction
+                                        (logger-hostname logger)
+                                        (logger-app-name logger)
+                                        (logger-process-id logger)
+                                        nil ; msgid
+                                        nil ; sd-elements
+                                        (apply #'format nil control args)))))))
+
+(defmacro rfc-log ((logger priority control &rest args) &body structured-data)
+  "Log the message formed by CONTROL and ARGS to the logger LOGGER with priority PRIORITY. Structured data should be a list of structured data clauses of the form, where each clause has the form:
+    (:MSGID <string>)
+
+ or
+
+    (<ID> <PARAM 1> <VALUE 1>
+          <PARAM 2> <VALUE 2>
+          ...)
+
+The data <ID> and <PARAM n> are symbols, while <VALUE n> are strings. Both <ID> and <PARAM n> are *not* evaluated, while <VALUE n> are evaluated.
+
+If :MSGID is provided, then this will be the RFC5424 msgid of the log message.
+
+The logging will only happen of LOGGER does not exceed a specified maximum priority value."
+  (assert (keywordp priority))
+  ;; Change PRIORITY into its numerical value. This also provides
+  ;; compile-time checking that PRIORITY is valid.
+  (setf priority (get-priority priority))
+
+  (let* ((msgid-form nil)
+         (sd-forms
+           ;; Parse out the structured data.
+           (loop :for sd :in structured-data
+                 :if (and (listp sd)
+                          (= 2 (length sd))
+                          (eql ':msgid (first sd)))
+                   :do (setf msgid-form (second sd))
+                 :else
+                   :collect
+                   (progn
+                     ;; Check that it's a list.
+                     (unless (alexandria:proper-list-p sd)
+                       (error "In RFC-LOG, encountered a piece of structured data that's not a list."))
+                     (unless (oddp (length sd))
+                       (error "In RFC-LOG, encountered a malformed structured data specification. It ~
+                                 should be a list of odd length."))
+                     (destructuring-bind (id &rest params) sd
+                       ;; FIND-SD-ID will error if it's invalid or unknown.
+                       (with-slots (allow-other-params fields) (find-sd-id id)
+                         ;; We found it, now we want to parse it all
+                         ;; out. Buckle up for a wild ride.
+                         (loop
+                           :with seen := nil
+                           :for (key val-form) :on params :by #'cddr
+                           :collect (let* ((already-seen? (find key seen :test #'string=))
+                                           (recognized? (find key
+                                                              fields
+                                                              :key #'structured-data-field-description-name
+                                                              :test #'string=))
+                                           ;; alias for readability.
+                                           (field-descriptor recognized?))
+                                      ;; Is it recognized?
+                                      (unless (or recognized? allow-other-params)
+                                        (error "Unrecognized field ~S in structured data ~S"
+                                               key
+                                               id))
+
+                                      ;; Do we allow repeats?
+                                      (unless (and recognized?
+                                                   already-seen?
+                                                   (structured-data-field-description-repetitions-allowed-p field-descriptor))
+                                        (error "Found a repeated field ~S for the structured data ~S, and that's not allowed here."
+                                               key
+                                               id))
+                                      ;; Create the param constructor.
+                                      `(make-param ',(string key)
+                                                   ,val-form))
+                             :into param-forms
+                           :finally (return `(make-sd-element ',(string id) ,@param-forms)))))))))
+    (alexandria:with-gensyms (year month day hour minute second fraction ; time
+                                   stream)
+      (alexandria:once-only (logger)
+        ;; Generate the logging code. Do *NOT* evaluate anything or do
+        ;; anything costly if our priority isn't correct.
+        `(unless (< (get-priority (logger-maximum-priority ,logger)) ',priority)
+           (multiple-value-bind (,year ,month ,day ,hour ,minute ,second ,fraction)
+               (current-time logger)
+             (with-output-to-string (,stream)
+               (write-rfc5424-syslog-message ,stream
+                                             (logior ',priority
+                                                     ;; facility is already shifted by 3 bits
+                                                     (get-facility (logger-facility ,logger)))
+                                             ,year
+                                             ,month
+                                             ,day
+                                             ,hour
+                                             ,minute
+                                             ,second
+                                             ,fraction
+                                             (logger-hostname ,logger)
+                                             (logger-app-name ,logger)
+                                             (logger-process-id ,logger)
+                                             ,msgid-form
+                                             (list ,@sd-forms)
+                                             (format nil ,control ,@args)))))))))
+

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -605,7 +605,7 @@ The :VALIDATOR keyword allows a validating function to be provided. By default i
 (defclass rfc5424-logger ()
   ((facility :initarg :facility
              :reader logger-facility
-             :documentation "The syslog facility, as a keyword. This is a required slot.")
+             :documentation "The syslog facility, as a keyword.")
    (maximum-priority :initarg :maximum-priority
                      :reader logger-maximum-priority
                      :documentation "The maximum priority above which log messages are not emitted to the external logging facility. The default maximum priority is :INFO. (Recall that priorities of *increasing* severity have *decreasing* priority values.)")
@@ -626,7 +626,8 @@ Example: A value akin to (lambda (p s) (write-line s)) is appropriate if all log
 Note: This isn't a \"writer\" in the usual CLOS sense.
 
 See also: The functions STREAM-LOG-WRITER, TEE-TO-STREAM, UDP-LOG-WRITER."))
-  (:default-initargs :maximum-priority ':info
+  (:default-initargs :facility ':user
+                     :maximum-priority ':info
                      :hostname (machine-instance)
                      :app-name nil
                      :process-id #+(and sbcl unix) (prin1-to-string (sb-posix:getpid))

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -596,6 +596,22 @@ The :VALIDATOR keyword allows a validating function to be provided. By default i
                                  #-(and sbcl unix) nil)
   (:documentation "Default class representing RFC 5424-compliant logging."))
 
+(defmethod shared-initialize :before ((logger rfc5424-logger) (slot-names t)
+                                        &key facility maximum-priority
+                                             hostname app-name process-id
+                                        &allow-other-keys)
+  ;; Do some sanity checking.
+  (assert (and (keywordp facility)
+               (get-facility facility)))
+  (assert (and (keywordp maximum-priority)
+               (get-priority maximum-priority)))
+  (assert (or (null hostname)
+              (stringp hostname)))
+  (assert (or (null app-name)
+              (stringp app-name)))
+  (assert (or (null process-id)
+              (stringp process-id))))
+
 (defgeneric current-time (logger)
   (:documentation "Return values YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, FRACTION-OF-A-SECOND.")
   (:method ((logger rfc5424-logger))

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -709,7 +709,7 @@ The logging will only happen of LOGGER does not exceed a specified maximum prior
         ;; anything costly if our priority isn't correct.
         `(unless (< (get-priority (logger-maximum-priority ,logger)) ',priority)
            (multiple-value-bind (,year ,month ,day ,hour ,minute ,second ,fraction)
-               (current-time logger)
+               (current-time ,logger)
              (with-output-to-string (,stream)
                (write-rfc5424-syslog-message ,stream
                                              (logior ',priority

--- a/rfc5424.lisp
+++ b/rfc5424.lisp
@@ -604,8 +604,8 @@ The :VALIDATOR keyword allows a validating function to be provided. By default i
       (declare (ignore daylight-p zone weekday))
       (values year month day hour minute second nil))))
 
-(defgeneric log-string (logger priority control &rest args)
-  (:documentation "Log the simple message STRING according to the priority PRIORITY.
+(defgeneric format-log (logger priority control &rest args)
+  (:documentation "Log the simple message STRING according to the priority PRIORITY. Note that this function behaves like CL:FORMAT, so ~'s in the CONTROL string will be interpreted as such.
 
 This should be used in the simplest of logging situations. For more complicated log messages that contain structured data, see the RFC-LOG macro.")
   (:method ((logger rfc5424-logger) priority control &rest args)


### PR DESCRIPTION
This PR is adding [RFC 5424](https://www.rfc-editor.org/rfc/pdfrfc/rfc5424.txt.pdf) compliance to CL-SYSLOG. It does so by building atop existing functionality. In particular, it adds a new `rfc5424-logger` class, along with a `log-string` function and an `rfc-log` macro.

It is *incomplete* and ~*not ready to merge*~. There are still some TODO items:

- [x] Clean up the file a bit.
- [x] Figure out where and how streams should be used
- [x] Add README documentation
- [ ] Add tests

With that said, all features of RFC5424 are present, including structured data, and log processors seem to understand it OK.